### PR TITLE
wrapped function called twice

### DIFF
--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -302,7 +302,6 @@ class Cache(object):
                         if current_app.debug:
                             raise
                         logger.exception("Exception possibly due to cache backend.")
-                        return f(*args, **kwargs)
                 return rv
 
             def make_cache_key(*args, **kwargs):


### PR DESCRIPTION
don't call the wrapped function if there's an exception while setting the cache.
